### PR TITLE
Adjusted markers for manual tests, so we no longer need to adjust the boolean.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,7 +52,7 @@ jobs:
         run: venv\Scripts\python dev-tools/devTools.py --diagram=pdf --keep-results
 
       - name: Test with pytest
-        run: venv\Scripts\python dev-tools/devTools.py --unit --keep-results
+        run: venv\Scripts\python dev-tools/devTools.py --unit "not manual" --keep-results
 #
 #      - name: Post coverage report to Coveralls
 #        uses: coverallsapp/github-action@master

--- a/dev-tools/devTools.py
+++ b/dev-tools/devTools.py
@@ -208,9 +208,8 @@ def _maybeRunPytest(arguments, testResultsDirPath):
         and not arguments.shallCreateRelease
     )
     if arguments.shallRunAll or arguments.pytestMarkersExpression is not None or wasCalledWithoutArguments:
-        # markerExpressions = _getMarkerExpressions(arguments.pytestMarkersExpression)
-        # additionalArgs = ["-m", markerExpressions]
-        additionalArgs = ""
+        markerExpressions = _getMarkerExpressions(arguments.pytestMarkersExpression)
+        additionalArgs = ["-m", markerExpressions]
 
         cmd = [
             _SCRIPTS_DIR / "pytest",

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,8 +2,9 @@
 python_files = test*
 python_classes = Test*
 python_functions = test*
-addopts = -v --ignore=src/oemof-thermal
+addopts = -v --ignore=src/oemof-thermal -m "not manual"
 #--ignore=src/oemof-solph
 # one ignore is needed for every folder, otherwise we could use: norecursedirs = src 
-
+markers =
+  manual: ignore when running all the tests (deselect with '-m "not manual"')
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 python_files = test*
 python_classes = Test*
 python_functions = test*
-addopts = -v --ignore=src/oemof-thermal -m "not manual"
+addopts = -v --ignore=src/oemof-thermal
 #--ignore=src/oemof-solph
 # one ignore is needed for every folder, otherwise we could use: norecursedirs = src 
 markers =

--- a/tests/Visualizer/test_visualize_energy_network.py
+++ b/tests/Visualizer/test_visualize_energy_network.py
@@ -21,8 +21,6 @@ filter_results = False   #False
 include_links = True
 building_no = 1
 
-manual = True          #True
-
 # Helper functions
 def get_building_no(node):
     """Extract building number from node or return 0 if not present."""
@@ -33,7 +31,7 @@ def is_link(node):
     return "link" in node.lower()
 
 
-@_pt.mark.skipif(manual, reason="Manual test of visualizer")
+@_pt.mark.manual
 class TestVisualizeEnergyNetwork(_ut.TestCase):
     def setUp(self):
         self.maxDiff = None
@@ -68,7 +66,7 @@ class TestVisualizeEnergyNetwork(_ut.TestCase):
         self.assertEqual(True, False)  # add assertion here
 
 
-@_pt.mark.skipif(manual, reason="Manual test of visualizer")
+@_pt.mark.manual
 class TestVisualizeEnergyNetwork_from_csv(_ut.TestCase):
     def setUp(self):
         self.maxDiff = None


### PR DESCRIPTION
Add the following before a test to mark it as a manual test:
```
@_pt.mark.manual
def test_something():
```

Then run the tests using either:
` pytest -m "not manual"`
or
`venv\Scripts\python dev-tools/devTools.py --unit "not manual" --keep-results`